### PR TITLE
Support narrowing down area queries with species parameters

### DIFF
--- a/docs/source/api/taxon.rst
+++ b/docs/source/api/taxon.rst
@@ -1,0 +1,6 @@
+taxon API
+==============
+
+The taxon API provides common species name, scientific species name, and subgroup name for all salmon taxons in the database. When calling the API externally via web request, the `session` parameter is not supplied; it will be automatically supplied by the backend.
+
+.. autofunction:: scip.api.population

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,6 +15,7 @@ This backend serves data about predefined regions and the locations and details 
    overview
    api/region
    api/population
+   api/taxon
 
 
 

--- a/scip/api/__init__.py
+++ b/scip/api/__init__.py
@@ -5,8 +5,9 @@ from flask import request
 
 from scip.api.region import region
 from scip.api.population import population
+from scip.api.taxon import taxon
 
-methods = {"region": region, "population": population}
+methods = {"region": region, "population": population, "taxon": taxon}
 
 __all__ = list(methods.keys()) + ["call"]
 

--- a/scip/api/population.py
+++ b/scip/api/population.py
@@ -29,9 +29,9 @@ def population(
 
     """
     if common_name:
-        common_name = parse_common_name(common_name)
+        common_name = parse_common_name(session, common_name)
     if subgroup:
-        subgroup = parse_subgroup(common_name, subgroup)
+        subgroup = parse_subgroup(session, common_name, subgroup)
 
     # TODO: return additional data
 

--- a/scip/api/population.py
+++ b/scip/api/population.py
@@ -2,6 +2,7 @@ from salmon_occurrence import ConservationUnit, Taxon, Reference, Population, Ph
 from sqlalchemy_sqlschema import maintain_schema
 from sqlalchemy_sqlschema.sql import get_schema
 from sqlalchemy import func
+from scip.api.validators import parse_common_name, parse_subgroup
 
 
 def population(
@@ -17,8 +18,7 @@ def population(
 
     :param session: (sqlalchemy.orm.session.Session) a database Session object
     :param overlap: a WKT string specifying a geometry that overlaps with the desired populations
-    :param common_name: common name of the salmon species of interest
-    :param scientific_name: scientific name of the salmon species of interest
+    :param common_name: a salmon species - Chinook Chum, Coho, Pink, or Sockeye
     :param subgroup: parameter designating a sub-species taxon, such as `lake` or `river` for sockeye salmon
     :param name: name of the conservation unit that encloses the population's range
 
@@ -28,7 +28,10 @@ def population(
         and `outlet` provides the most downstream point of the extent according to the RVIC routed flow data.
 
     """
-    # TODO: verify input arguments
+    if common_name:
+        common_name = parse_common_name(common_name)
+    if subgroup:
+        subgroup = parse_subgroup(common_name, subgroup)
 
     # TODO: return additional data
 
@@ -55,8 +58,6 @@ def population(
 
         if common_name:
             q = q.filter(Taxon.common_name == common_name)
-        if scientific_name:
-            q = q.filter(Taxon.scientific_name == scientific_name)
         if subgroup:
             q = q.filter(Taxon.subgroup == subgroup)
 

--- a/scip/api/region.py
+++ b/scip/api/region.py
@@ -57,7 +57,6 @@ def region(
                     ConservationUnit.code.label("code"),
                     func.ST_AsGeoJSON(ConservationUnit.boundary).label("boundary"),
                     func.ST_ASGeoJSON(ConservationUnit.outlet).label("outlet"),
-                    func.ST_Area(Region.boundary).label("area"),
                 )
             else:
                 # conservation unit with species - join to Population table
@@ -68,7 +67,6 @@ def region(
                         ConservationUnit.code.label("code"),
                         func.ST_AsGeoJSON(ConservationUnit.boundary).label("boundary"),
                         func.ST_ASGeoJSON(ConservationUnit.outlet).label("outlet"),
-                        func.ST_Area(Region.boundary).label("area"),
                     )
                     .join(
                         Population,
@@ -101,7 +99,6 @@ def region(
                     Region.kind.label("kind"),
                     func.ST_AsGeoJSON(Region.boundary).label("boundary"),
                     func.ST_AsGeoJSON(Region.outlet).label("outlet"),
-                    func.ST_Area(Region.boundary).label("area"),
                 ).filter(Region.kind == kind)
             else:
                 # watershed/basin with species parameters - do a spatial
@@ -114,7 +111,6 @@ def region(
                         Region.kind.label("kind"),
                         func.ST_AsGeoJSON(Region.boundary).label("boundary"),
                         func.ST_AsGeoJSON(Region.outlet).label("outlet"),
-                        func.ST_Area(Region.boundary).label("area"),
                     )
                     .join(
                         ConservationUnit,
@@ -148,7 +144,7 @@ def region(
         result_list = [
             {
                 att: getattr(result, att)
-                for att in ["name", "code", "outlet", "boundary", "area"]
+                for att in ["name", "code", "outlet", "boundary"]
             }
             for result in results
         ]

--- a/scip/api/region.py
+++ b/scip/api/region.py
@@ -1,7 +1,5 @@
-from salmon_occurrence import Region, ConservationUnit, Population, Taxon
 from sqlalchemy_sqlschema import maintain_schema
 from sqlalchemy_sqlschema.sql import get_schema
-from sqlalchemy import func
 from scip.api.validators import parse_region_kind, parse_common_name, parse_subgroup
 from scip.api.region_helpers import build_cu_query, build_region_query
 
@@ -29,11 +27,11 @@ def region(
     """
     with maintain_schema("public, salmon_geometry", session):
         # check parameters
-        kind = parse_region_kind(kind)
+        kind = parse_region_kind(session, kind)
         if common_name:
-            common_name = parse_common_name(common_name)
+            common_name = parse_common_name(session, common_name)
         if subgroup:
-            subgroup = parse_subgroup(common_name, subgroup)
+            subgroup = parse_subgroup(session, common_name, subgroup)
 
         # TODO: check overlap, see https://github.com/pacificclimate/scip-frontend/issues/43
 

--- a/scip/api/region_helpers.py
+++ b/scip/api/region_helpers.py
@@ -1,0 +1,138 @@
+# The functions in this file assist the region API to build queries
+# needed to provide information about "regions" (polygons) in the postGIS
+# database. The polygons are stored in two different tables in the database,
+# Regions and ConservationUnits, but are presented identically to the user.
+
+# Additionally, the API user may specify that they only wish to see regions
+# in which certain species of salmon are found. The two geometry-recording
+# tables have different relationships to the Population table, which records
+# salmon information. Therefore, there are four possible types of queries
+# that might need to be constructed:
+# 1. conservation unit with species: build_cu_query -> cu_with_taxon
+# 2. conservation unit without species: build_cu_query -> cu_geometry_only
+# 3. other region with species: build_region_query -> region_with_taxon
+# 4. other region without species: build_region_query -> region_geometry_only
+
+from salmon_occurrence import Region, ConservationUnit, Population, Taxon
+from sqlalchemy import func
+
+
+def cu_with_taxon(session, common_name, subgroup):
+    """Returns a query that joins the conservation unit table with the population table, in order to get a list of conservation units that contain a particular salmon species"""
+    q = (
+        session.query(
+            ConservationUnit.name.label("name"),
+            ConservationUnit.code.label("code"),
+            func.ST_AsGeoJSON(ConservationUnit.boundary).label("boundary"),
+            func.ST_ASGeoJSON(ConservationUnit.outlet).label("outlet"),
+        )
+        .join(
+            Population,
+            Population.conservation_unit_id == ConservationUnit.id,
+        )
+        .join(Taxon, Population.taxon_id == Taxon.id)
+        .filter(Taxon.common_name == common_name)
+    )
+
+    if subgroup:
+        q = q.filter(Taxon.subgroup == subgroup)
+    q = q.distinct(ConservationUnit.name)
+
+    return q
+
+
+def cu_geometry_only(session):
+    """Returns a simple query on the conservation unit table"""
+    q = session.query(
+        ConservationUnit.name.label("name"),
+        ConservationUnit.code.label("code"),
+        func.ST_AsGeoJSON(ConservationUnit.boundary).label("boundary"),
+        func.ST_ASGeoJSON(ConservationUnit.outlet).label("outlet"),
+    )
+
+    return q
+
+
+def build_cu_query(
+    session, overlap=None, name=None, code=None, common_name=None, subgroup=None
+):
+    """Creates an SQLalchemy query to get information about conservation units"""
+    if common_name:
+        q = cu_with_taxon(session, common_name, subgroup)
+    else:
+        q = cu_geometry_only(session)
+
+    if overlap:
+        q = q.filter(ConservationUnit.boundary.ST_Intersects(overlap))
+
+    if name:
+        q = q.filter(ConservationUnit.name == name)
+
+    if code:
+        q = q.filter(ConservationUnit.code == code)
+
+    return q
+
+
+def region_with_taxon(session, kind, common_name, subgroup):
+    """Returns a query that spatially joins the regions table with the conservation units table, in order to access salmon population info"""
+    q = (
+        session.query(
+            Region.name.label("name"),
+            Region.code.label("code"),
+            Region.kind.label("kind"),
+            func.ST_AsGeoJSON(Region.boundary).label("boundary"),
+            func.ST_AsGeoJSON(Region.outlet).label("outlet"),
+        )
+        .join(
+            ConservationUnit,
+            ConservationUnit.boundary.ST_Intersects(Region.boundary),
+        )
+        .join(
+            Population,
+            Population.conservation_unit_id == ConservationUnit.id,
+        )
+        .join(Taxon, Population.taxon_id == Taxon.id)
+        .filter(Region.kind == kind)
+        .filter(Taxon.common_name == common_name)
+    )
+
+    if subgroup:
+        q = q.filter(Taxon.subgroup == subgroup)
+    q = q.distinct(Region.name)
+
+    return q
+
+
+def region_geometry_only(session, kind):
+    """Returns a simple query on the regions table"""
+    q = session.query(
+        Region.name.label("name"),
+        Region.code.label("code"),
+        Region.kind.label("kind"),
+        func.ST_AsGeoJSON(Region.boundary).label("boundary"),
+        func.ST_AsGeoJSON(Region.outlet).label("outlet"),
+    ).filter(Region.kind == kind)
+
+    return q
+
+
+def build_region_query(
+    session, kind, overlap=None, name=None, code=None, common_name=None, subgroup=None
+):
+    """Creates and SQLAlchemy query to get information about watersheds or basins"""
+    if common_name:
+        q = region_with_taxon(session, kind, common_name, subgroup)
+    else:
+        q = region_geometry_only(session, kind)
+
+    if overlap:
+        q = q.filter(Region.boundary.ST_Intersects(overlap))
+
+    if name:
+        q = q.filter(Region.name == name)
+
+    if code:
+        q = q.filter(Region.code == code)
+
+    return q

--- a/scip/api/region_helpers.py
+++ b/scip/api/region_helpers.py
@@ -36,7 +36,7 @@ def cu_with_taxon(session, common_name, subgroup):
 
     if subgroup:
         q = q.filter(Taxon.subgroup == subgroup)
-    q = q.distinct(ConservationUnit.name, Taxon.id)
+    q = q.distinct()
 
     return q
 
@@ -99,7 +99,7 @@ def region_with_taxon(session, kind, common_name, subgroup):
 
     if subgroup:
         q = q.filter(Taxon.subgroup == subgroup)
-    q = q.distinct(Region.name)
+    q = q.distinct()
 
     return q
 

--- a/scip/api/region_helpers.py
+++ b/scip/api/region_helpers.py
@@ -36,7 +36,7 @@ def cu_with_taxon(session, common_name, subgroup):
 
     if subgroup:
         q = q.filter(Taxon.subgroup == subgroup)
-    q = q.distinct(ConservationUnit.name)
+    q = q.distinct(ConservationUnit.name, Taxon.id)
 
     return q
 

--- a/scip/api/region_helpers.py
+++ b/scip/api/region_helpers.py
@@ -1,38 +1,36 @@
-# The functions in this file assist the region API to build queries
-# needed to provide information about "regions" (polygons) in the postGIS
-# database. The polygons are stored in two different tables in the database,
-# Regions and ConservationUnits, but are presented identically to the user.
+"""
+The functions in this file assist the region API to build queries
+needed to provide information about "regions" (polygons) in the postGIS
+database. The polygons are stored in two different tables in the database,
+Regions and ConservationUnits, but are presented identically to the user.
 
-# Additionally, the API user may specify that they only wish to see regions
-# in which certain species of salmon are found. The two geometry-recording
-# tables have different relationships to the Population table, which records
-# salmon information. Therefore, there are four possible types of queries
-# that might need to be constructed:
-# 1. conservation unit with species: build_cu_query -> cu_with_taxon
-# 2. conservation unit without species: build_cu_query -> cu_geometry_only
-# 3. other region with species: build_region_query -> region_with_taxon
-# 4. other region without species: build_region_query -> region_geometry_only
+Additionally, the API user may specify that they only wish to see regions
+in which certain species of salmon are found. The two geometry-recording
+tables have different relationships to the Population table, which records
+salmon information. Therefore, there are four possible types of queries
+that might need to be constructed:
+ 1. conservation unit with species: build_cu_query -> cu_with_taxon
+ 2. conservation unit without species: build_cu_query -> cu_geometry_only
+ 3. other region with species: build_region_query -> region_with_taxon
+ 4. other region without species: build_region_query -> region_geometry_only
+"""
 
 from salmon_occurrence import Region, ConservationUnit, Population, Taxon
 from sqlalchemy import func
 
 
 def cu_with_taxon(session, common_name, subgroup):
-    """Returns a query that joins the conservation unit table with the population table, in order to get a list of conservation units that contain a particular salmon species"""
-    q = (
-        session.query(
-            ConservationUnit.name.label("name"),
-            ConservationUnit.code.label("code"),
-            func.ST_AsGeoJSON(ConservationUnit.boundary).label("boundary"),
-            func.ST_ASGeoJSON(ConservationUnit.outlet).label("outlet"),
-        )
-        .join(
-            Population,
-            Population.conservation_unit_id == ConservationUnit.id,
-        )
-        .join(Taxon, Population.taxon_id == Taxon.id)
-        .filter(Taxon.common_name == common_name)
+    """Returns a query that joins the conservation unit table
+    with the population table, in order to get a list of
+    conservation units that contain a particular salmon species"""
+    q = cu_geometry_only(session)
+
+    q = q.join(
+        Population,
+        Population.conservation_unit_id == ConservationUnit.id,
     )
+    q = q.join(Taxon, Population.taxon_id == Taxon.id)
+    q = q.filter(Taxon.common_name == common_name)
 
     if subgroup:
         q = q.filter(Taxon.subgroup == subgroup)
@@ -56,7 +54,8 @@ def cu_geometry_only(session):
 def build_cu_query(
     session, overlap=None, name=None, code=None, common_name=None, subgroup=None
 ):
-    """Creates an SQLalchemy query to get information about conservation units"""
+    """Creates an SQLalchemy query to get information about
+    conservation units"""
     if common_name:
         q = cu_with_taxon(session, common_name, subgroup)
     else:
@@ -75,27 +74,19 @@ def build_cu_query(
 
 
 def region_with_taxon(session, kind, common_name, subgroup):
-    """Returns a query that spatially joins the regions table with the conservation units table, in order to access salmon population info"""
-    q = (
-        session.query(
-            Region.name.label("name"),
-            Region.code.label("code"),
-            Region.kind.label("kind"),
-            func.ST_AsGeoJSON(Region.boundary).label("boundary"),
-            func.ST_AsGeoJSON(Region.outlet).label("outlet"),
-        )
-        .join(
-            ConservationUnit,
-            ConservationUnit.boundary.ST_Intersects(Region.boundary),
-        )
-        .join(
-            Population,
-            Population.conservation_unit_id == ConservationUnit.id,
-        )
-        .join(Taxon, Population.taxon_id == Taxon.id)
-        .filter(Region.kind == kind)
-        .filter(Taxon.common_name == common_name)
+    """Returns a query that spatially joins the regions table with the
+    conservation units table, in order to access salmon population info"""
+    q = region_geometry_only(session, kind)
+    q = q.join(
+        ConservationUnit,
+        ConservationUnit.boundary.ST_Intersects(Region.boundary),
     )
+    q = q.join(
+        Population,
+        Population.conservation_unit_id == ConservationUnit.id,
+    )
+    q = q.join(Taxon, Population.taxon_id == Taxon.id)
+    q = q.filter(Taxon.common_name == common_name)
 
     if subgroup:
         q = q.filter(Taxon.subgroup == subgroup)

--- a/scip/api/taxon.py
+++ b/scip/api/taxon.py
@@ -1,0 +1,31 @@
+from sqlalchemy_sqlschema import maintain_schema
+from sqlalchemy_sqlschema.sql import get_schema
+from salmon_occurrence import Taxon
+
+
+def taxon(session):
+    """Very simple API with no parameters. Returns a list of all salmon taxons in the
+    database.
+
+    :param session: (sqlalchemy.orm.session.Session) a database Session object
+
+    :return: a list of objects representing salmon taxons in the database. A taxon has
+        a scientific name, a common name, and optionall a subgroup.
+    """
+    q = session.query(
+        Taxon.common_name.label("common_name"),
+        Taxon.scientific_name.label("scientific_name"),
+        Taxon.subgroup.label("subgroup"),
+    )
+
+    results = q.all()
+
+    result_list = [
+        {
+            att: getattr(result, att)
+            for att in ["common_name", "scientific_name", "subgroup"]
+        }
+        for result in results
+    ]
+
+    return result_list

--- a/scip/api/validators.py
+++ b/scip/api/validators.py
@@ -67,7 +67,7 @@ def parse_wkt(wkt):
             + regex_point
             + ", "
             + regex_point
-            + ", ("
+            + "(, "
             + regex_point
             + ")*\)\)$"
         )

--- a/scip/api/validators.py
+++ b/scip/api/validators.py
@@ -1,0 +1,84 @@
+# helper functions used to validate request parameters
+import re
+
+
+def parse_region_kind(kind):
+    k = kind.lower()
+    kinds = ["basin", "watershed", "conservation_unit"]
+    if k in kinds:
+        return k
+    else:
+        raise ValueError(
+            "Unsupported region kind: {}. Supported kinds: {}".format(kind, kinds)
+        )
+
+
+def parse_common_name(cn):
+    species = ["Chinook", "Chum", "Coho", "Pink", "Sockeye"]
+    s = cn.lower().capitalize()
+    if s in species:
+        return s
+    else:
+        raise ValueError(
+            "Unknown salmon species: {}. Known species: {}".format(s, species)
+        )
+
+
+def parse_subgroup(species, subgroup):
+    subgroups = {"Odd": "Pink", "Even": "Pink", "Lake": "Sockeye", "River": "Sockeye"}
+    sg = subgroup.lower().capitalize()
+
+    if sg in subgroups and subgroups[sg] == species:
+        return sg
+    elif species in subgroups.values():
+        raise ValueError("Unknown subgroup of species {}: {}".format(species, sg))
+    elif species in ["Chinook", "Chum", "Coho"]:
+        raise ValueError("No subgroups for {} are known".format(species))
+    else:
+        raise ValueError("Unknown salmon species {}".format(species))
+
+
+# This code has been taken out of use following the discovery that the
+# front end sometimes passes geoJSON, which - absent WKT verification code -
+# was not previously noticed. TODO: fix the front end, then return this check
+# to use.
+# https://github.com/pacificclimate/scip-frontend/issues/43
+
+
+# we are expecting points or single polygons only here.
+# it will need to be updated if the front end starts generating other
+# shapes.
+# wkt geometries may optionally have a space between the geometry type
+# (like "POINT") and the opening parenthesis for the coordinate string.
+# the front end doesn't generate WKT with a space, so it's not supported
+# by this function, even though it is valid WKT.
+def parse_wkt(wkt):
+    regex_point = "-?(\d+(?:\.\d*)?) -?(\d+(?:\.\d*)?)"
+    if wkt.startswith("POINT"):
+        template = "^POINT\(" + regex_point + "\)$"
+        print(template)
+        if re.match(template, wkt):
+            return wkt
+        else:
+            raise ValueError("Could not parse WKT POINT: {}".format(wkt))
+    elif wkt.startswith("POLYGON"):
+        template = (
+            "^POLYGON\(\("
+            + regex_point
+            + ", "
+            + regex_point
+            + ", ("
+            + regex_point
+            + ")*\)\)$"
+        )
+
+        if re.match(template, wkt):
+            return wkt
+        else:
+            raise ValueError("Could not parse WKT POLYGON: {}".format(wkt))
+    else:
+        raise ValueError(
+            "Can't parse WKT, Only POINT and POLYGON geometries are supported. {}".format(
+                wkt
+            )
+        )

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -25,16 +25,24 @@ def test_population_by_species(db_populated_session, species, expected):
     "species,subgroup,expected",
     [
         ["Chum", None, [PCH1, PCH2]],
-        ["Chum", "Banana", []],
-        ["Chum", "Odd", []],
+        ["Chum", "Banana", "error"],
+        ["Chum", "Odd", "error"],
         ["Pink", "Odd", [PPKO]],
         ["Pink", "Even", [PPKE]],
-        [None, "Even", [PPKE]],
+        [None, "Even", "error"],
     ],
 )
 def test_population_by_subgroup(db_populated_session, species, subgroup, expected):
-    response = population(db_populated_session, common_name=species, subgroup=subgroup)
-    check_populations(expected, response)
+    if expected == "error":
+        with pytest.raises(Exception) as e:
+            response = population(
+                db_populated_session, common_name=species, subgroup=subgroup
+            )
+    else:
+        response = population(
+            db_populated_session, common_name=species, subgroup=subgroup
+        )
+        check_populations(expected, response)
 
 
 @pytest.mark.parametrize(
@@ -62,10 +70,16 @@ def test_population_by_overlap_point(db_populated_session, x, y, species, expect
         [None, [PCH2, PPKO, PPKE]],
         ["Pink", [PPKO, PPKE]],
         ["Chum", [PCH2]],
-        ["Banana", []],
+        ["Banana", "error"],
     ],
 )
 def test_population_by_overlap_polygon(db_populated_session, species, expected):
     wkt = "POLYGON((15 15, 15 20, 20 20, 20 15, 15 15))"
-    response = population(db_populated_session, common_name=species, overlap=wkt)
-    check_populations(expected, response)
+    if expected == "error":
+        with pytest.raises(Exception) as e:
+            response = population(
+                db_populated_session, common_name=species, overlap=wkt
+            )
+    else:
+        response = population(db_populated_session, common_name=species, overlap=wkt)
+        check_populations(expected, response)

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -13,7 +13,7 @@ def test_population_listing(db_populated_session):
 
 # check listing by species
 @pytest.mark.parametrize(
-    "species,expected", [["Chum", [PCH1, PCH2]], ["Pink", [PPKO, PPKE]], ["Coho", []]]
+    "species,expected", [["Chum", [PCH1, PCH2]], ["Pink", [PPKO, PPKE]]]
 )
 def test_population_by_species(db_populated_session, species, expected):
     response = population(db_populated_session, common_name=species)

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -77,3 +77,44 @@ def test_region_overlap_point(db_populated_session, x, y, kind, expected):
 def test_region_overlap_polygon(db_populated_session):
     response = region(db_populated_session, kind="watershed", overlap=BAS1["boundary"])
     check_regions([WAT1, WAT2], response)
+
+
+@pytest.mark.parametrize(
+    "species,subgroup,kind,expected",
+    [
+        ("Pink", "Odd", "conservation_unit", [CUPO]),
+        ("Pink", "Even", "conservation_unit", [CUPE]),
+        ("Pink", None, "conservation_unit", [CUPO, CUPE]),
+        ("Pink", "Odd", "basin", []),
+        ("Pink", "Even", "basin", [BAS1]),
+        ("Chum", None, "conservation_unit", [CUC1, CUC2]),
+        ("Chum", None, "watershed", [WAT1, WAT2]),
+    ],
+)
+def test_region_by_species(db_populated_session, species, subgroup, kind, expected):
+    response = region(
+        db_populated_session, kind=kind, common_name=species, subgroup=subgroup
+    )
+    check_regions(expected, response)
+
+
+@pytest.mark.parametrize(
+    "species,subgroup,boundary,kind,expected",
+    [
+        ("Pink", "Odd", WAT1, "watershed", []),
+        ("Pink", "Odd", WAT3, "watershed", [WAT3]),
+        ("Pink", "Even", WAT1, "watershed", [WAT1, WAT2]),
+        ("Pink", "Even", WAT1, "basin", [BAS1]),
+    ],
+)
+def test_region_by_species_and_overlap(
+    db_populated_session, species, subgroup, boundary, kind, expected
+):
+    response = region(
+        db_populated_session,
+        kind=kind,
+        common_name=species,
+        subgroup=subgroup,
+        overlap=boundary["boundary"],
+    )
+    check_regions(expected, response)

--- a/tests/test_taxon.py
+++ b/tests/test_taxon.py
@@ -1,0 +1,22 @@
+import pytest
+import json
+from scip.api import taxon
+from sample_data import CHUM, PNKO, PNKE
+
+
+# taxon only does one thing and accepts no parameters,
+# testing it is not very complicated.
+def test_taxon_listing(db_populated_session):
+    response = taxon(db_populated_session)
+    expected_taxons = [CHUM, PNKO, PNKE]
+    assert (len(response)) == len(expected_taxons)
+    for t in expected_taxons:
+        matched = False
+        for r in response:
+            if (
+                r["common_name"] == t["common_name"]
+                and r["subgroup"] == t["subgroup"]
+                and r["scientific_name"] == t["scientific_name"]
+            ):
+                matched = True
+        assert matched == True, "Expected salmon taxon not found: {}".format(t)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -17,30 +17,30 @@ from sample_data import WAT1, WAT2, WAT3, BAS1
         ("banana", "error"),
     ],
 )
-def test_parsing_regions(kind, expected):
+def test_parsing_regions(db_populated_session, kind, expected):
     if expected is "error":
         with pytest.raises(ValueError) as e:
-            parse_region_kind(kind)
+            parse_region_kind(db_populated_session, kind)
     else:
-        assert parse_region_kind(kind) == expected
+        assert parse_region_kind(db_populated_session, kind) == expected
 
 
 @pytest.mark.parametrize(
     "species,expected",
     [
         ("Chum", "Chum"),
-        ("sockeye", "Sockeye"),
+        ("pink", "Pink"),
         ("Chummmm", "error"),
         ("Banana", "error"),
         ("489", "error"),
     ],
 )
-def test_parsing_species(species, expected):
+def test_parsing_species(db_populated_session, species, expected):
     if expected is "error":
         with pytest.raises(ValueError) as e:
-            parse_common_name(species)
+            parse_common_name(db_populated_session, species)
     else:
-        assert parse_common_name(species) == expected
+        assert parse_common_name(db_populated_session, species) == expected
 
 
 @pytest.mark.parametrize(
@@ -55,12 +55,12 @@ def test_parsing_species(species, expected):
         ("Chum", "Banana", "error"),
     ],
 )
-def test_parsing_subgroups(species, subgroup, expected):
+def test_parsing_subgroups(db_populated_session, species, subgroup, expected):
     if expected is "error":
         with pytest.raises(ValueError) as e:
-            parse_subgroup(species, subgroup)
+            parse_subgroup(db_populated_session, species, subgroup)
     else:
-        assert parse_subgroup(species, subgroup) == expected
+        assert parse_subgroup(db_populated_session, species, subgroup) == expected
 
 
 @pytest.mark.parametrize("region", [WAT1, WAT2, WAT3, BAS1])

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,96 @@
+import pytest
+from scip.api.validators import (
+    parse_region_kind,
+    parse_common_name,
+    parse_subgroup,
+    parse_wkt,
+)
+from sample_data import WAT1, WAT2, WAT3, BAS1
+
+
+@pytest.mark.parametrize(
+    "kind,expected",
+    [
+        ("Basin", "basin"),
+        ("basin", "basin"),
+        ("watershed", "watershed"),
+        ("banana", "error"),
+    ],
+)
+def test_parsing_regions(kind, expected):
+    if expected is "error":
+        with pytest.raises(ValueError) as e:
+            parse_region_kind(kind)
+    else:
+        assert parse_region_kind(kind) == expected
+
+
+@pytest.mark.parametrize(
+    "species,expected",
+    [
+        ("Chum", "Chum"),
+        ("sockeye", "Sockeye"),
+        ("Chummmm", "error"),
+        ("Banana", "error"),
+        ("489", "error"),
+    ],
+)
+def test_parsing_species(species, expected):
+    if expected is "error":
+        with pytest.raises(ValueError) as e:
+            parse_common_name(species)
+    else:
+        assert parse_common_name(species) == expected
+
+
+@pytest.mark.parametrize(
+    "species,subgroup,expected",
+    [
+        ("Pink", "Odd", "Odd"),
+        ("Pink", "odd", "Odd"),
+        ("Pink", "even", "Even"),
+        ("Chum", "Even", "error"),
+        ("Pink", "Lake", "error"),
+        ("Pink", "Banana", "error"),
+        ("Chum", "Banana", "error"),
+    ],
+)
+def test_parsing_subgroups(species, subgroup, expected):
+    if expected is "error":
+        with pytest.raises(ValueError) as e:
+            parse_subgroup(species, subgroup)
+    else:
+        assert parse_subgroup(species, subgroup) == expected
+
+
+@pytest.mark.parametrize("region", [WAT1, WAT2, WAT3, BAS1])
+def test_parsing_wkt_polygons(region):
+    assert region["boundary"] == parse_wkt(region["boundary"])
+
+
+@pytest.mark.parametrize("region", [WAT1, WAT2, WAT3, BAS1])
+def test_parsing_wkt_points(region):
+    assert region["outlet"] == parse_wkt(region["outlet"])
+
+
+@pytest.mark.parametrize(
+    "bad_wkt",
+    [
+        "POINT",
+        "BANANA",
+        "BANANA(0 0)",
+        "POINT()",
+        "POINT(0 0 0 0)",
+        "POINT(0)",
+        "POLYGON((5 5 5 15, 15 15, 15 5, 5 5))",
+        "POINT(BANANA BANANA)",
+        "POINT(5 BANANA)"
+        "POLYGON()"
+        "POLYGON(())"
+        "POLYGON((5 5, 5 15))"
+        "POLYGON ((5 5, 5 15, 15 15, 15 5, 5 5))",
+    ],
+)
+def test_parsing_invalid_wkt(bad_wkt):
+    with pytest.raises(ValueError) as e:
+        parse_wkt(bad_wkt)


### PR DESCRIPTION
We would like users of the front end to be able to find the watershed they care about by specifying which salmon species they are interested in. To this end, we need the `region` query in the back end to accept parameters for `common_name` and optionally `subgroup` and only return regions in which salmon of that species and subgroup are present.

Questions for reviewers:
* the database query is constructed differently depending on parameters received, which might be confusing. Have I [explained the logic adequately in comments](https://github.com/pacificclimate/scip-backend/blob/8e96cf23ebc83c19e4001b4f8f874bdf61ca7f62/scip/api/region.py#L39)?
* for parameter verification, there are now hardcoded lists of valid region kinds, salmon species and salmon species subgroups in [validators.py](https://github.com/pacificclimate/scip-backend/blob/8e96cf23ebc83c19e4001b4f8f874bdf61ca7f62/scip/api/validators.py). I chose to do it this way for speed, but perhaps it would be better to fetch these lists from the database. Opinions?

Resolves #6 