### PR TITLE
support POST requests

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,6 +8,8 @@ SCIP backend documentation
 
 This backend serves data about predefined regions and the locations and details of salmon population to the Salmon Climate Impacts Portal (SCIP).
 
+It accepts parameters either as GET or POST requests. Clients should send GET requests when possible, to facilitate caching and fast return of their queries. However, there are cases where the 'overlap' parameter, a WKT string describing the extent of a region the client wishes information about, is so long it will not fit into a standard 4096 character URL. In those cases, the client may send a POST request with parameters in JSON format in the body.
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:

--- a/scip/api/__init__.py
+++ b/scip/api/__init__.py
@@ -19,10 +19,12 @@ def call(session, request_type):
     except KeyError:
         return Response("Endpoint {} not recognized".format(request_type), status=400)
 
-    # check for required arguments
+    # check for required arguments - using request.values checkes
+    # both parameters in URL strings and parameters in JSON-style request 
+    # bodies.  
     required_params = set(get_required_args(func)).difference(["session"])
 
-    provided_params = set(request.args.keys())
+    provided_params = set(request.values.keys())
     optional_params = set(get_keyword_args(func))
 
     missing_params = required_params.difference(provided_params)
@@ -31,11 +33,11 @@ def call(session, request_type):
             "Missing query parameters: {}".format(missing_params), status=400
         )
 
-    args = {key: request.args.get(key) for key in required_params}
+    args = {key: request.values.get(key) for key in required_params}
     kwargs = {
-        key: request.args.get(key)
+        key: request.values.get(key)
         for key in optional_params
-        if request.args.get(key) is not None
+        if request.values.get(key) is not None
     }
 
     args.update(kwargs)

--- a/scip/api/__init__.py
+++ b/scip/api/__init__.py
@@ -20,8 +20,8 @@ def call(session, request_type):
         return Response("Endpoint {} not recognized".format(request_type), status=400)
 
     # check for required arguments - using request.values checkes
-    # both parameters in URL strings and parameters in JSON-style request 
-    # bodies.  
+    # both parameters in URL strings and parameters in JSON-style request
+    # bodies.
     required_params = set(get_required_args(func)).difference(["session"])
 
     provided_params = set(request.values.keys())

--- a/scip/routes.py
+++ b/scip/routes.py
@@ -6,7 +6,7 @@ import scip.api as api
 def add_routes(app):
     db = SQLAlchemy(app)
 
-    @app.route("/api/<request_type>")
+    @app.route("/api/<request_type>", methods=['GET', 'POST'])
     def api_request(*args, **kwargs):
         return api.call(db.session, *args, **kwargs)
 

--- a/scip/routes.py
+++ b/scip/routes.py
@@ -6,7 +6,7 @@ import scip.api as api
 def add_routes(app):
     db = SQLAlchemy(app)
 
-    @app.route("/api/<request_type>", methods=['GET', 'POST'])
+    @app.route("/api/<request_type>", methods=["GET", "POST"])
     def api_request(*args, **kwargs):
         return api.call(db.session, *args, **kwargs)
 


### PR DESCRIPTION
The PCEX backend was having difficulty with very long URLS - specifically, URLs containing a WKT string describing a complex area. We have [updated](https://github.com/pacificclimate/climate-explorer-backend/pull/229) the PCEX backend to accept parameters in the body of a POST request, which has no length limits.

Long parameter strings have not posed an issue on this backend, despite receiving the same long WKT strings, but we anticipate that they are likely to in the future due to deployment considerations like gunicorn, caches, or various user browsers, so I want to update it as well. 

This backend previously accessed client-supplied URL parameters from flask's `request.args`, but I have switched it to the _extremely_ convenient `request.values`, which includes both URL parameters and body parameters (provided they're supplied in JSON format) in a single dictionary, so the code doesn't have to know or care how the parameters arrive. 

resolves #9 