### PR TITLE
enable sqlalchemy's pre-ping functionality

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install Poetry
         run: |
-          pip install poetry
+          pip install poetry==1.8.5
 
       - name: Install project
         run: |

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install Poetry
         run: |
-          curl -sSL https://install.python-poetry.org | python3 -
+          pip install poetry
 
       - name: Install project
         run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 RUN apt-get update
 RUN apt-get -yq install python3 python3-dev
 RUN apt-get -yq install python3-pip postgresql-client
-RUN apt-get -yq install curl libpq-dev
+RUN apt-get -yq install curl libpq-dev python3-poetry
 
 ENV FLASK_APP scip.wsgi:app
 
@@ -11,9 +11,8 @@ RUN mkdir /app
 WORKDIR /app
 ADD . /app/
 
-RUN curl -sSL https://install.python-poetry.org | python3 -
 RUN export PATH="/root/.local/bin:$PATH"
-RUN /root/.local/bin/poetry install
+RUN poetry install
 
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 ADD . /app/
 
 RUN export PATH="/root/.local/bin:$PATH"
-RUN pip install poetry
+RUN pip install poetry==1.8.5
 RUN poetry install
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 RUN apt-get update
 RUN apt-get -yq install python3 python3-dev
 RUN apt-get -yq install python3-pip postgresql-client
-RUN apt-get -yq install curl libpq-dev python3-poetry
+RUN apt-get -yq install curl libpq-dev
 
 ENV FLASK_APP scip.wsgi:app
 
@@ -12,6 +12,7 @@ WORKDIR /app
 ADD . /app/
 
 RUN export PATH="/root/.local/bin:$PATH"
+RUN pip install poetry
 RUN poetry install
 
 

--- a/scip/__init__.py
+++ b/scip/__init__.py
@@ -14,6 +14,7 @@ def get_app():
         "DB", "postgresql://scip_ro@db.pcic.uvic.ca/scip"
     )
     app.config["SQLALCHEMY_TRACK_MODIFICATION"] = False
+    app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {"pool_pre_ping": True}
 
     add_routes(app)
     return app


### PR DESCRIPTION
Turn on SQLAlchemy's feature to test the database connection and reconnect if needed before sending a query.

[Here's a demo](https://beehive.pacificclimate.org/scip/app) running against this backend, but there shouldn't be any visible changes. It should just drop the database connection less often.

For unclear reasons, installing `poetry` via the recommended command `curl -sSL https://install.python-poetry.org | python3 - ` is not working in github actions (in neither this repository nor in station data portal backend), though it works fine on beehive and on a docker container run on my desktop. I switched to installing `poetry` with `pip`, for both github actions and the main docker container because I think it's less confusing if everything uses the same methods. If @Nospamas has a suggestion for a better way to handle this, I'd love to have it.

Resolves #14 